### PR TITLE
Removing dependencies to James 2.3.2 libraries.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -134,18 +134,7 @@
 					<groupId>javax.mail</groupId>
 				</exclusion>
 			</exclusions>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.james</groupId>
-			<artifactId>james</artifactId>
-			<version>2.3.2</version>
-			<exclusions>
-				<exclusion>
-					<artifactId>mail</artifactId>
-					<groupId>javax.mail</groupId>
-				</exclusion>
-			</exclusions>
-		</dependency>				
+		</dependency>			
 		<dependency>
 			<groupId>commons-net</groupId>
 			<artifactId>commons-net</artifactId>

--- a/src/main/java/org/nhindirect/smtpmq/gateway/server/MessageSizeException.java
+++ b/src/main/java/org/nhindirect/smtpmq/gateway/server/MessageSizeException.java
@@ -1,0 +1,23 @@
+package org.nhindirect.smtpmq.gateway.server;
+
+import java.io.IOException;
+
+/**
+ * Taken from the apache james 2.3.2 server which is no longer in the main maven repository.
+ *
+ */
+public class MessageSizeException extends IOException
+{
+    /**
+	 * 
+	 */
+	private static final long serialVersionUID = 420903468326823983L;
+
+	/**
+     * Sole contructor for this class.  This constructor sets
+     * the exception message to a fixed error message.
+     */
+    public MessageSizeException() {
+        super("Message size exceeds fixed maximum message size.");
+    }
+}

--- a/src/main/java/org/nhindirect/smtpmq/gateway/server/SMTPMessageHandler.java
+++ b/src/main/java/org/nhindirect/smtpmq/gateway/server/SMTPMessageHandler.java
@@ -15,7 +15,6 @@ import javax.mail.internet.MimeMessage;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.input.CountingInputStream;
-import org.apache.james.smtpserver.MessageSizeException;
 import org.nhindirect.common.mail.SMTPMailMessage;
 import org.nhindirect.smtpmq.gateway.streams.SmtpGatewayMessageSource;
 import org.slf4j.Logger;

--- a/src/main/java/org/nhindirect/smtpmq/gateway/server/SizeLimitedInputStream.java
+++ b/src/main/java/org/nhindirect/smtpmq/gateway/server/SizeLimitedInputStream.java
@@ -1,0 +1,69 @@
+package org.nhindirect.smtpmq.gateway.server;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+
+/**
+ * Taken from the apache james 2.3.2 server which is no longer in the main maven repository.
+ *
+ */
+public class SizeLimitedInputStream extends InputStream
+{
+	   /**
+     * Maximum number of bytes to read.
+     */
+    private long maxmessagesize = 0;
+    /**
+     * Running total of bytes read from wrapped stream.
+     */
+    private long bytesread = 0;
+
+    /**
+     * InputStream that will be wrapped.
+     */
+    private InputStream in = null;
+
+    /**
+     * Constructor for the stream. Wraps an underlying stream.
+     * @param in InputStream to use as basis for new Stream.
+     * @param maxmessagesize Message size limit, in Kilobytes
+     */
+    public SizeLimitedInputStream(InputStream in, long maxmessagesize) {
+        this.in = in;
+        this.maxmessagesize = maxmessagesize;
+    }
+
+    /**
+     * Overrides the read method of InputStream to call the read() method of the
+     * wrapped input stream.
+     * @throws IOException Throws a MessageSizeException, which is a sub-type of IOException
+     * @return Returns the number of bytes read.
+     */
+    public int read(byte[] b, int off, int len) throws IOException {
+        int l = in.read(b, off, len);
+
+        bytesread += l;
+
+        if (maxmessagesize > 0 && bytesread > maxmessagesize) {
+            throw new MessageSizeException();
+        }
+
+        return l;
+    }
+
+    /**
+     * Overrides the read method of InputStream to call the read() method of the
+     * wrapped input stream.
+     * @throws IOException Throws a MessageSizeException, which is a sub-type of IOException.
+     * @return Returns the int character value of the byte read.
+     */
+    public int read() throws IOException {
+        if (maxmessagesize > 0 && bytesread <= maxmessagesize) {
+            bytesread++;
+            return in.read();
+        } else {
+            throw new MessageSizeException();
+        }
+    }
+}

--- a/src/main/java/org/nhindirect/smtpmq/gateway/server/SizeLimitedInputStreamFactory.java
+++ b/src/main/java/org/nhindirect/smtpmq/gateway/server/SizeLimitedInputStreamFactory.java
@@ -2,8 +2,6 @@ package org.nhindirect.smtpmq.gateway.server;
 
 import java.io.InputStream;
 
-import org.apache.james.smtpserver.SizeLimitedInputStream;
-
 public class SizeLimitedInputStreamFactory
 {
     private static SizeLimitedInputStreamFactory instance = new SizeLimitedInputStreamFactory();


### PR DESCRIPTION
The james library is no longer available in the main maven repo.
Copying the MessagingSizeException and SizeLimiteInputStream classes
from the old library.